### PR TITLE
Update .gitignore to exclude additional files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+nohup.out
+qdrant_storage
+qdrant_snapshots
+nomic-embed-text-v1.5.f16.gguf
+paragraph_embed.wasm


### PR DESCRIPTION
Add entries to the .gitignore file to prevent tracking of specific output and storage files.